### PR TITLE
Add TiddlyWiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A curated list of packages, tools, and other software with zero third-party depe
 | [sqlpkg](https://github.com/nalgeon/sqlpkg-cli)                | SQLite package manager                   | Go         | MIT           |
 | [steganography](https://github.com/auyer/steganography)        | LSB steganography on images              | Go         | MIT           |
 | [tagger](https://github.com/jcubic/tagger)                     | Tag editor                               | JavaScript | MIT           |
+| [TiddlyWiki](https://github.com/Jermolene/TiddlyWiki5)         | Self-contained Wiki                      | JavaScript | BSD-3-Clause  |
 | [toml](https://github.com/BurntSushi/toml)                     | TOML serialization                       | Go         | MIT           |
 | [utf8.h](https://github.com/sheredom/utf8.h)                   | UTF-8 string functions                   | C          | Unlicense     |
 | [uuid](https://github.com/google/uuid)                         | Generate and inspect UUIDs               | Go         | BSD-3-Clause  |
@@ -51,7 +52,6 @@ A curated list of packages, tools, and other software with zero third-party depe
 | [xid](https://github.com/rs/xid)                               | Globally unique ID generator             | Go         | MIT           |
 | [xxhash](https://github.com/cespare/xxhash)                    | 64-bit xxHash algorithm (XXH64)          | Go         | MIT           |
 | [yaegi](https://github.com/traefik/yaegi)                      | Go interpreter                           | Go         | Apache-2.0    |
-| [TiddlyWiki](https://github.com/Jermolene/TiddlyWiki5)         | Self-contained Wiki                      | JavaScript | BSD-3-Clause  |
 
 ## Frequently asked questions
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated list of packages, tools, and other software with zero third-party depe
 | [xid](https://github.com/rs/xid)                               | Globally unique ID generator             | Go         | MIT           |
 | [xxhash](https://github.com/cespare/xxhash)                    | 64-bit xxHash algorithm (XXH64)          | Go         | MIT           |
 | [yaegi](https://github.com/traefik/yaegi)                      | Go interpreter                           | Go         | Apache-2.0    |
+| [TiddlyWiki](https://github.com/Jermolene/TiddlyWiki5)         | Self-contained Wiki                      | JavaScript | BSD-3-Clause  |
 
 ## Frequently asked questions
 


### PR DESCRIPTION
So technically TiddlyWiki has one dev dependency on `eslint`, but that feels like more of a convenient way to keep track of a tool than an actual requirement for the build process.

Other than that, TiddlyWiki feels _deeply_ in-line with the spirit of the zero-dependencies club. It's a whole, very featureful wiki in a single HTML file (as in, you can `Ctrl-S` it to a thumb drive and take it with you).